### PR TITLE
Navigation overscroll fix

### DIFF
--- a/assets/sass/partials.sass
+++ b/assets/sass/partials.sass
@@ -38,8 +38,11 @@ header
 nav
 	+break(max, $break-2)
 		z-index: $z-top
-		grid-row: 2 / 5
-		grid-column: 2 / 3
+		position: fixed
+		top: $units * 4
+		left: 0
+		width: 100vw
+		height: calc(100vh - #{$units * 4})
 		background-color: rgba($white, 0.96)
 
 		display: grid
@@ -48,9 +51,6 @@ nav
 
 		+transitionWithProperties(transform)
 		transform: translate3d(calc(100% + 4px), 0, 0)
-
-		&.revealed
-			transform: translate3d(0, 0, 0)
 
 		ul
 			grid-row: 1
@@ -61,6 +61,9 @@ nav
 			grid-template-rows: auto
 			align-items: center
 			justify-items: center
+
+		&.revealed
+			transform: translate3d(0, 0, 0)
 
 	+break(min, $break-2)
 		grid-row: 1 / 2
@@ -76,6 +79,7 @@ nav
 			display: grid
 			grid-auto-flow: column
 			grid-gap: $units
+			margin-right: $units
 
 /**
  *	Teaser photo

--- a/assets/sass/setup.sass
+++ b/assets/sass/setup.sass
@@ -7,8 +7,11 @@ body
 	display: grid
 	grid-template-columns: 1fr minmax(auto, $max-width) 1fr
 	grid-template-rows: ($units * 4) 1fr ($units * 2) ($units * 6)
-	overflow-x: hidden
-	height: 100vh
+	
+	&.nav-revealed
+		height: 100vh
+		position: fixed
+		overflow: hidden
 
 ul
 	list-style: none

--- a/assets/scripts/utils.js
+++ b/assets/scripts/utils.js
@@ -37,12 +37,15 @@ window.cinematt.utils = {
 
 	toggleMenuReveal: () => {
 		let nav 	= document.querySelector('nav'),
+			body	= document.querySelector('body'),
 			button	= document.querySelector('button');
 
 		if(nav.classList.toggle('revealed')) {
+			body.classList.add('nav-revealed');
 			button.classList.add('opened');
 		}
 		else {
+			body.classList.remove('nav-revealed');
 			button.classList.remove('opened');
 		}
 	},


### PR DESCRIPTION
This PR fixes and issue with navigation overscroll on Safari (desktop/iOS):

- The nav menu is taken out of the grid flow and now has a fixed position on mobile devices.
- The `overflow: hidden` with `position: fixed` is set on the body when the nav is revealed. This prevents scrolling on iOS devices.