### PR TITLE
Navigation fix

### DIFF
--- a/assets/sass/layouts/pages.sass
+++ b/assets/sass/layouts/pages.sass
@@ -2,6 +2,7 @@
  *	The landing page
  */
 main.landing
+	z-index: 1
 	display: grid
 	grid-column: 2 / 3
 	grid-row: 2 / 3

--- a/assets/sass/partials.sass
+++ b/assets/sass/partials.sass
@@ -61,7 +61,6 @@ nav
 		align-self: start
 
 		opacity: 0
-		+transitionWithProperties(opacity)
 
 		ul
 			display: grid

--- a/assets/sass/partials.sass
+++ b/assets/sass/partials.sass
@@ -2,84 +2,33 @@
  *	Header
  */
 header
-	grid-row: 1 / 2
-	grid-column: 2 / 3
-	display: grid
-	align-items: center
-	background-color: rgba($white, 0.8)
-
-	h1
-		margin-left: $units
-
-	button 
-		svg.button-close
-			display: none
-
-		&.opened
-			svg.button-menu
-				display: none
-			svg.button-close
-				display: unset
-
-	+break(max, $break-2)
-		grid-template-columns: 1fr $units * 4
-		grid-template-rows: 1fr
-
-		button 
-			grid-column: 2 / 3
-			height: $units * 4
-
-	+break(min, $break-2)
-		button
-			display: none
-/**
- *	navigation
- */
-nav
-	+break(max, $break-2)
-		z-index: $z-top
-		position: fixed
-		top: $units * 4
-		left: 0
-		width: 100vw
-		height: calc(100vh - #{$units * 4})
-		background-color: rgba($white, 0.96)
-
-		display: grid
-		grid-template-rows: minmax(auto, 75vh)
-		grid-template-columns: 1fr
-
-		+transitionWithProperties(transform)
-		transform: translate3d(calc(100% + 4px), 0, 0)
-
-		ul
-			grid-row: 1
-			grid-column: 1
-
-			display: grid
-			grid-template-columns: 1fr
-			grid-template-rows: auto
-			align-items: center
-			justify-items: center
-
-		&.revealed
-			transform: translate3d(0, 0, 0)
-
 	+break(min, $break-2)
 		grid-row: 1 / 2
 		grid-column: 2 / 3
-
 		display: grid
-		grid-template-columns: repeat(2, 1fr)
-		grid-template-rows: 1fr
+		grid-template-rows: minmax($units * 4, 1fr)
+		grid-template-columns: $units repeat(2, auto) $units
 		align-items: center
 
-		ul
+		> a
 			grid-column: 2 / 3
+			grid-row: 1 / 2
+				
+		button 
+			display: none
+
+/**
+ *	Navigation
+ */
+nav
+	+break(min, $break-2)
+		grid-column: 3 / 4
+		grid-row: 1 / 2
+
+		ul
 			display: grid
 			grid-auto-flow: column
-			grid-gap: $units
-			margin-right: $units
+			justify-items: end
 
 /**
  *	Teaser photo

--- a/assets/sass/partials.sass
+++ b/assets/sass/partials.sass
@@ -2,6 +2,40 @@
  *	Header
  */
 header
+
+	+break(max, $break-2)
+		grid-row: 1 / 5
+		grid-column: 2 / 3
+		display: grid
+		grid-template-rows: minmax($units * 4, auto) 1fr 
+		grid-template-columns: $units repeat(2, auto) $units
+		align-items: center
+		background-color: $white
+		overflow-x: hidden
+
+		> a
+			grid-column: 2 / 3
+			grid-row: 1 / 2
+
+		button
+			grid-column: 3 / 4
+			grid-row: 1 / 2
+			justify-self: end
+
+			svg.button-close
+				display: none
+
+			&.opened
+				svg.button-close
+					display: unset
+				svg.button-menu
+					display: none
+
+		&.revealed
+			z-index: $z-top
+			nav
+				opacity: 1.0
+
 	+break(min, $break-2)
 		grid-row: 1 / 2
 		grid-column: 2 / 3
@@ -21,6 +55,20 @@ header
  *	Navigation
  */
 nav
+	+break(max, $break-2)
+		grid-column: 1 / 5
+		grid-row: 2 / 3
+		align-self: start
+
+		opacity: 0
+		+transitionWithProperties(opacity)
+
+		ul
+			display: grid
+			grid-auto-flow: row
+			justify-items: center
+			grid-row-gap: ($units * 3)
+
 	+break(min, $break-2)
 		grid-column: 3 / 4
 		grid-row: 1 / 2

--- a/assets/sass/setup.sass
+++ b/assets/sass/setup.sass
@@ -6,12 +6,14 @@
 body
 	display: grid
 	grid-template-columns: 1fr minmax(auto, $max-width) 1fr
-	grid-template-rows: auto 1fr ($units * 2) ($units * 6)
-	
-	&.nav-revealed
-		// height: 100vh
-		// position: fixed
-		// overflow: hidden
+	// grid-template-rows: $units * 4 1fr ($units * 2) ($units * 6)
+	grid-template-rows: $units * 4 auto
+	// grid-auto-flow: row
+	height: 100vh
+
+	&.menu-open
+		main
+			z-index: -1
 
 ul
 	list-style: none

--- a/assets/sass/setup.sass
+++ b/assets/sass/setup.sass
@@ -6,12 +6,12 @@
 body
 	display: grid
 	grid-template-columns: 1fr minmax(auto, $max-width) 1fr
-	grid-template-rows: ($units * 4) 1fr ($units * 2) ($units * 6)
+	grid-template-rows: auto 1fr ($units * 2) ($units * 6)
 	
 	&.nav-revealed
-		height: 100vh
-		position: fixed
-		overflow: hidden
+		// height: 100vh
+		// position: fixed
+		// overflow: hidden
 
 ul
 	list-style: none

--- a/assets/scripts/utils.js
+++ b/assets/scripts/utils.js
@@ -36,17 +36,17 @@ window.cinematt.utils = {
 	},
 
 	toggleMenuReveal: () => {
-		let nav 	= document.querySelector('nav'),
-			body	= document.querySelector('body'),
+		let header	= document.querySelector('header'),
+			body 	= document.querySelector('body'),
 			button	= document.querySelector('button');
 
-		if(nav.classList.toggle('revealed')) {
-			body.classList.add('nav-revealed');
+		if(header.classList.toggle('revealed')) {
 			button.classList.add('opened');
+			body.classList.add('menu-open');
 		}
 		else {
-			body.classList.remove('nav-revealed');
 			button.classList.remove('opened');
+			body.classList.remove('menu-open');
 		}
 	},
 

--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -5,7 +5,6 @@
 	</head>
 	<body>
 		{{ partial "header" . }}
-		{{ partial "nav" . }}
 		<main class="page {{ .Params.title | urlize }}">
 			<article>
 				{{ .Content }}

--- a/site/layouts/albums/single.html
+++ b/site/layouts/albums/single.html
@@ -5,7 +5,6 @@
 	</head>
 	<body>
 		{{ partial "header" . }}
-		{{ partial "nav" . }}
 		<main class="page albums">
 			{{ if .Params.teaser_image}}
 				{{ $teaser 		:= string .Params.teaser_image }}

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -5,7 +5,6 @@
 	</head>
 	<body>
 		{{ partial "header" . }}
-		{{ partial "nav" . }}
 		<main class="page landing">
 			{{ $intro := string .Site.Params.intro_photo }}
 			{{ $photos := where .Data.Pages "Section" "photos" }}

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -14,4 +14,5 @@
 			</use>
 		</svg>
 	</button>
+	{{ partial "nav" . }}
 </header>

--- a/site/layouts/partials/nav.html
+++ b/site/layouts/partials/nav.html
@@ -12,8 +12,9 @@
 			</li>
 		{{ end }}
 		{{ range $menu }}
+			{{ $active 	:= eq $title .Name }}
 			<li>
-				<a href="{{ .URL }}">
+				<a href="{{ .URL }}" {{ if $active }}class="active"{{ end }}>
 					{{ .Name }}
 				</a>
 			</li>

--- a/site/layouts/photos/single.html
+++ b/site/layouts/photos/single.html
@@ -5,7 +5,6 @@
 	</head>
 	<body>
 		{{ partial "header" . }}
-		{{ partial "nav" . }}
 		<main class="page photo">
 			<figure>
 				{{ partial "picture_wide" . }}


### PR DESCRIPTION
This PR includes the following changes:

- Refactored the styling for `header` and `nav` items for desktop and mobile.
- Simplified the hide/show for navigation and removed `positon: fixed` which caused Safari to crash.
- The `nav` element now sits inside the `header` element.