### PR TITLE
Fixes and features

### DIFF
--- a/assets/sass/layouts/pages.sass
+++ b/assets/sass/layouts/pages.sass
@@ -2,6 +2,7 @@
  *	The landing page
  */
 main.landing
+	z-index: 1
 	display: grid
 	grid-column: 2 / 3
 	grid-row: 2 / 3

--- a/assets/sass/mixins.sass
+++ b/assets/sass/mixins.sass
@@ -3,10 +3,10 @@
 		@media screen and (min-width: $param-break-1)
 			@content
 	@else if $type == max
-		@media screen and (max-width: $param-break-1)
+		@media screen and (max-width: $param-break-1 - 0.0625rem)
 			@content
 	@else if $type == min-max
-		@media screen and (min-width: $param-break-1) and (max-width: $param-break-2 - 0.05rem)
+		@media screen and (min-width: $param-break-1) and (max-width: $param-break-2 - 0.0625rem)
 			@content
 
 =transitionWithProperties($props, $ms: $transition-duration)

--- a/assets/sass/partials.sass
+++ b/assets/sass/partials.sass
@@ -7,7 +7,7 @@ header
 		grid-row: 1 / 5
 		grid-column: 2 / 3
 		display: grid
-		grid-template-rows: minmax($units * 4, auto) 1fr 
+		grid-template-rows: minmax($units * 4, $units * 8) 1fr 
 		grid-template-columns: $units repeat(2, auto) $units
 		align-items: center
 		background-color: $white

--- a/assets/sass/partials.sass
+++ b/assets/sass/partials.sass
@@ -61,7 +61,6 @@ nav
 		align-self: start
 
 		opacity: 0
-		+transitionWithProperties(opacity)
 
 		ul
 			display: grid

--- a/assets/sass/partials.sass
+++ b/assets/sass/partials.sass
@@ -2,84 +2,33 @@
  *	Header
  */
 header
-	grid-row: 1 / 2
-	grid-column: 2 / 3
-	display: grid
-	align-items: center
-	background-color: rgba($white, 0.8)
-
-	h1
-		margin-left: $units
-
-	button 
-		svg.button-close
-			display: none
-
-		&.opened
-			svg.button-menu
-				display: none
-			svg.button-close
-				display: unset
-
-	+break(max, $break-2)
-		grid-template-columns: 1fr $units * 4
-		grid-template-rows: 1fr
-
-		button 
-			grid-column: 2 / 3
-			height: $units * 4
-
-	+break(min, $break-2)
-		button
-			display: none
-/**
- *	navigation
- */
-nav
-	+break(max, $break-2)
-		z-index: $z-top
-		position: fixed
-		top: $units * 4
-		left: 0
-		width: 100vw
-		height: calc(100vh - #{$units * 4})
-		background-color: rgba($white, 0.96)
-
-		display: grid
-		grid-template-rows: minmax(auto, 75vh)
-		grid-template-columns: 1fr
-
-		+transitionWithProperties(transform)
-		transform: translate3d(calc(100% + 4px), 0, 0)
-
-		ul
-			grid-row: 1
-			grid-column: 1
-
-			display: grid
-			grid-template-columns: 1fr
-			grid-template-rows: auto
-			align-items: center
-			justify-items: center
-
-		&.revealed
-			transform: translate3d(0, 0, 0)
-
 	+break(min, $break-2)
 		grid-row: 1 / 2
 		grid-column: 2 / 3
-
 		display: grid
-		grid-template-columns: repeat(2, 1fr)
-		grid-template-rows: 1fr
+		grid-template-rows: minmax($units * 4, 1fr)
+		grid-template-columns: $units repeat(2, auto) $units
 		align-items: center
 
-		ul
+		> a
 			grid-column: 2 / 3
+			grid-row: 1 / 2
+				
+		button 
+			display: none
+
+/**
+ *	Navigation
+ */
+nav
+	+break(min, $break-2)
+		grid-column: 3 / 4
+		grid-row: 1 / 2
+
+		ul
 			display: grid
 			grid-auto-flow: column
-			grid-gap: $units
-			margin-right: $units
+			justify-items: end
 
 /**
  *	Teaser photo

--- a/assets/sass/partials.sass
+++ b/assets/sass/partials.sass
@@ -2,6 +2,40 @@
  *	Header
  */
 header
+
+	+break(max, $break-2)
+		grid-row: 1 / 5
+		grid-column: 2 / 3
+		display: grid
+		grid-template-rows: minmax($units * 4, auto) 1fr 
+		grid-template-columns: $units repeat(2, auto) $units
+		align-items: center
+		background-color: $white
+		overflow-x: hidden
+
+		> a
+			grid-column: 2 / 3
+			grid-row: 1 / 2
+
+		button
+			grid-column: 3 / 4
+			grid-row: 1 / 2
+			justify-self: end
+
+			svg.button-close
+				display: none
+
+			&.opened
+				svg.button-close
+					display: unset
+				svg.button-menu
+					display: none
+
+		&.revealed
+			z-index: $z-top
+			nav
+				opacity: 1.0
+
 	+break(min, $break-2)
 		grid-row: 1 / 2
 		grid-column: 2 / 3
@@ -21,6 +55,20 @@ header
  *	Navigation
  */
 nav
+	+break(max, $break-2)
+		grid-column: 1 / 5
+		grid-row: 2 / 3
+		align-self: start
+
+		opacity: 0
+		+transitionWithProperties(opacity)
+
+		ul
+			display: grid
+			grid-auto-flow: row
+			justify-items: center
+			grid-row-gap: ($units * 3)
+
 	+break(min, $break-2)
 		grid-column: 3 / 4
 		grid-row: 1 / 2

--- a/assets/sass/setup.sass
+++ b/assets/sass/setup.sass
@@ -6,9 +6,7 @@
 body
 	display: grid
 	grid-template-columns: 1fr minmax(auto, $max-width) 1fr
-	// grid-template-rows: $units * 4 1fr ($units * 2) ($units * 6)
-	grid-template-rows: $units * 4 auto
-	// grid-auto-flow: row
+	grid-template-rows: $units * 8 auto
 	height: 100vh
 
 	&.menu-open

--- a/assets/sass/setup.sass
+++ b/assets/sass/setup.sass
@@ -6,12 +6,14 @@
 body
 	display: grid
 	grid-template-columns: 1fr minmax(auto, $max-width) 1fr
-	grid-template-rows: auto 1fr ($units * 2) ($units * 6)
-	
-	&.nav-revealed
-		// height: 100vh
-		// position: fixed
-		// overflow: hidden
+	// grid-template-rows: $units * 4 1fr ($units * 2) ($units * 6)
+	grid-template-rows: $units * 4 auto
+	// grid-auto-flow: row
+	height: 100vh
+
+	&.menu-open
+		main
+			z-index: -1
 
 ul
 	list-style: none

--- a/assets/sass/setup.sass
+++ b/assets/sass/setup.sass
@@ -6,12 +6,12 @@
 body
 	display: grid
 	grid-template-columns: 1fr minmax(auto, $max-width) 1fr
-	grid-template-rows: ($units * 4) 1fr ($units * 2) ($units * 6)
+	grid-template-rows: auto 1fr ($units * 2) ($units * 6)
 	
 	&.nav-revealed
-		height: 100vh
-		position: fixed
-		overflow: hidden
+		// height: 100vh
+		// position: fixed
+		// overflow: hidden
 
 ul
 	list-style: none

--- a/assets/scripts/utils.js
+++ b/assets/scripts/utils.js
@@ -36,17 +36,17 @@ window.cinematt.utils = {
 	},
 
 	toggleMenuReveal: () => {
-		let nav 	= document.querySelector('nav'),
-			body	= document.querySelector('body'),
+		let header	= document.querySelector('header'),
+			body 	= document.querySelector('body'),
 			button	= document.querySelector('button');
 
-		if(nav.classList.toggle('revealed')) {
-			body.classList.add('nav-revealed');
+		if(header.classList.toggle('revealed')) {
 			button.classList.add('opened');
+			body.classList.add('menu-open');
 		}
 		else {
-			body.classList.remove('nav-revealed');
 			button.classList.remove('opened');
+			body.classList.remove('menu-open');
 		}
 	},
 

--- a/site/content/albums/abandoned.md
+++ b/site/content/albums/abandoned.md
@@ -3,6 +3,6 @@ date: 2017-05-31T13:45:38Z
 description: "The places long forgotten by most but still telling their stories."
 identifier: "abandoned"
 title: "Abandoned"
-weight: "9"
+weight: "1"
 teaser_image: "cite-foche-reflections.md"
 ---

--- a/site/content/albums/city.md
+++ b/site/content/albums/city.md
@@ -3,6 +3,6 @@ date: 2017-05-31T13:42:34Z
 description: "Urban architecture and people build the most beautiful colours."
 identifier: "city"
 title: "City"
-weight: "3"
+weight: "5"
 teaser_image: "berlin-christmas-market-bar.md"
 ---

--- a/site/content/albums/events.md
+++ b/site/content/albums/events.md
@@ -3,6 +3,6 @@ date: 2017-05-31T13:44:49Z
 description: "Events are always a nice excuse to take your camera out."
 identifier: "events"
 title: "Events"
-weight: "5"
+weight: "8"
 teaser_image: "spwc-dublin-waldos.md"
 ---

--- a/site/content/albums/landscapes.md
+++ b/site/content/albums/landscapes.md
@@ -3,6 +3,6 @@ date: 2017-05-31T13:42:04Z
 description: "I skipped the pub and went out with my camera. These are the things I saw."
 identifier: "landscapes"
 title: "Landscapes"
-weight: "2"
+weight: "6"
 teaser_image: "st-finians-beach.md"
 ---

--- a/site/content/albums/music.md
+++ b/site/content/albums/music.md
@@ -3,6 +3,6 @@ date: 2017-05-31T13:47:34Z
 description: "Musicians are the engineers of the soul."
 identifier: "music"
 title: "Music"
-weight: "8"
+weight: "3"
 teaser_image: "hot-sprockets-stage-vantastival.md"
 ---

--- a/site/content/albums/nature.md
+++ b/site/content/albums/nature.md
@@ -3,6 +3,6 @@ date: 2017-05-31T13:46:14Z
 description: "Cats, dogs, birds, deer, monkeys, horses and plants are all very photogenic."
 identifier: "nature"
 title: "Nature"
-weight: "6"
+weight: "9"
 teaser_image: "bird-poised.md"
 ---

--- a/site/content/albums/people.md
+++ b/site/content/albums/people.md
@@ -3,6 +3,6 @@ date: 2017-05-31T13:41:21Z
 description: "Years in the making. Come and meet some of these colourful characters."
 identifier: "people"
 title: "People"
-weight: "1"
+weight: "2"
 teaser_image: "viking-renactor.md"
 ---

--- a/site/content/photos/abandoned/cite-foche-anna-illuminated.md
+++ b/site/content/photos/abandoned/cite-foche-anna-illuminated.md
@@ -7,6 +7,7 @@ date:		"2016-08-21 19:07:18+00:00"
 album:		"abandoned"
 filename:		"cite-foche-anna-illuminated.md"
 series:		"cite-foche"
+weight:		6
 cl_public_id:		"abandoned/cite-foche-anna-illuminated"
 cl_version:		1497000046
 format:		"tiff"

--- a/site/content/photos/city/look-beautiful-tempelhof.md
+++ b/site/content/photos/city/look-beautiful-tempelhof.md
@@ -7,6 +7,7 @@ date:		"2013-02-15 15:08:56+00:00"
 album:		"city"
 filename:		"look-beautiful-tempelhof.md"
 series:		"tempelhof"
+weight: 	2
 cl_public_id:		"city/look-beautiful-tempelhof"
 cl_version:		1497000456
 format:		"tiff"

--- a/site/content/photos/events/spwc-dublin-waldos.md
+++ b/site/content/photos/events/spwc-dublin-waldos.md
@@ -7,6 +7,7 @@ date:		"2011-06-18 13:02:38+00:00"
 album:		"events"
 filename:		"spwc-dublin-waldos.md"
 series:		"outdoors"
+weight: 	7
 cl_public_id:		"events/spwc-dublin-waldos"
 cl_version:		1497002577
 format:		"tiff"

--- a/site/content/photos/experimental/building-pattern.md
+++ b/site/content/photos/experimental/building-pattern.md
@@ -7,6 +7,7 @@ date:		"2016-12-09 10:47:01+00:00"
 album:		"experimental"
 filename:		"building-pattern.md"
 series:		"architecture"
+weight: 	3
 cl_public_id:		"experimental/building-pattern"
 cl_version:		1497004427
 format:		"tiff"

--- a/site/content/photos/landscapes/glendalough-path.md
+++ b/site/content/photos/landscapes/glendalough-path.md
@@ -7,6 +7,7 @@ date:		"2014-04-08 14:40:28+00:00"
 album:		"landscapes"
 filename:		"glendalough-path.md"
 series:		"glendalough"
+weight: 	1
 cl_public_id:		"landscapes/glendalough-path"
 cl_version:		1497004677
 format:		"tiff"

--- a/site/content/photos/music/alabama-3-lead.md
+++ b/site/content/photos/music/alabama-3-lead.md
@@ -7,6 +7,7 @@ date:		"2011-05-01 23:31:50+00:00"
 album:		"music"
 filename:		"alabama-3-lead.md"
 series:		"vantastival"
+weight: 	4
 cl_public_id:		"music/alabama-3-lead"
 cl_version:		1497004809
 format:		"tiff"

--- a/site/content/photos/nature/bird-poised.md
+++ b/site/content/photos/nature/bird-poised.md
@@ -7,6 +7,7 @@ date:		"2011-09-24 16:01:53+00:00"
 album:		"nature"
 filename:		"bird-poised.md"
 series:		"spirit-of-folk"
+weight: 	8
 cl_public_id:		"nature/bird-poised"
 cl_version:		1497005045
 format:		"tiff"

--- a/site/content/photos/people/viking-renactor.md
+++ b/site/content/photos/people/viking-renactor.md
@@ -7,6 +7,7 @@ date:		"2011-09-24 17:19:06+00:00"
 album:		"people"
 filename:		"viking-renactor.md"
 series:		"spirit-of-folk"
+weight: 	5
 cl_public_id:		"people/viking-renactor"
 cl_version:		1497005597
 format:		"tiff"

--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -5,7 +5,6 @@
 	</head>
 	<body>
 		{{ partial "header" . }}
-		{{ partial "nav" . }}
 		<main class="page {{ .Params.title | urlize }}">
 			<article>
 				{{ .Content }}

--- a/site/layouts/albums/single.html
+++ b/site/layouts/albums/single.html
@@ -5,7 +5,6 @@
 	</head>
 	<body>
 		{{ partial "header" . }}
-		{{ partial "nav" . }}
 		<main class="page albums">
 			{{ if .Params.teaser_image}}
 				{{ $teaser 		:= string .Params.teaser_image }}

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -8,7 +8,8 @@
 		<main class="page landing">
 			{{ $intro := string .Site.Params.intro_photo }}
 			{{ $photos := where .Data.Pages "Section" "photos" }}
-			{{ range ($photos.ByParam "series") }}
+			
+			{{ range $photos.ByWeight}}
 				{{ .Render "card" }}
 			{{ end }}
 		</main>

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -5,7 +5,6 @@
 	</head>
 	<body>
 		{{ partial "header" . }}
-		{{ partial "nav" . }}
 		<main class="page landing">
 			{{ $intro := string .Site.Params.intro_photo }}
 			{{ $photos := where .Data.Pages "Section" "photos" }}

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -14,4 +14,5 @@
 			</use>
 		</svg>
 	</button>
+	{{ partial "nav" . }}
 </header>

--- a/site/layouts/partials/nav.html
+++ b/site/layouts/partials/nav.html
@@ -12,8 +12,9 @@
 			</li>
 		{{ end }}
 		{{ range $menu }}
+			{{ $active 	:= eq $title .Name }}
 			<li>
-				<a href="{{ .URL }}">
+				<a href="{{ .URL }}" {{ if $active }}class="active"{{ end }}>
 					{{ .Name }}
 				</a>
 			</li>

--- a/site/layouts/photos/single.html
+++ b/site/layouts/photos/single.html
@@ -5,7 +5,6 @@
 	</head>
 	<body>
 		{{ partial "header" . }}
-		{{ partial "nav" . }}
 		<main class="page photo">
 			<figure>
 				{{ partial "picture_wide" . }}


### PR DESCRIPTION
This PR has the following changes:

- The slide out navigation menu now uses grid for its layout and no longer uses a transform to appear. This addresses an issue where this would cause Safari to crash.
- The code for the top navigation functionality has been refactored.
- Photos on the landing page are sorted by weight, then by date.